### PR TITLE
Add support for RFC 2324's HTTP extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ app.use(function (err, req, res, next) {
 - 415: `new res.UnsupportedMediaType([code, ]message)`
 - 416: `new res.RangeNotSatisfied([code, ]message)`
 - 417: `new res.ExpectationFailed([code, ]message)`
+- 418: `new res.ImATeapot([code, ]message)`
 - 423: `new res.Locked([code, ]message)`
 - 428: `new res.PreconditionRequired([code, ]message)`
 - 429: `new res.TooManyRequests([code, ]message)`

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ var ResponseTypes = {
   UnsupportedMediaType: 415,
   RangeNotSatisfied: 416,
   ExpectationFailed: 417,
+  ImATeapot: 418,
   Locked: 423,
 
   UpgradeRequired: function (protocols, code, message) {


### PR DESCRIPTION
I can't help but notice this library isn't compatible with [RFC 2324](https://tools.ietf.org/html/rfc2324). This PR will make the library fully compatable.
