### PR TITLE
added isHttpResponsesError property to RestError to allow for appropr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,15 @@ app.use('/:id', function (req, res, next) {
         body: err.message
       }));
     }
-  });
+  }).catch(function (err) {
+    if (err.isHttpResponsesError) {
+        next(err)
+    } else {
+        next(new res.InternalServerError({
+            body: err.message
+        }));
+    }
+  })
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@
 var xml = require('js2xmlparser')
 var util = require('util')
 
-
 function RestError (type, status, code, message, headers) {
   Error.call(this)
   Error.captureStackTrace(this, this.constructor)
@@ -22,6 +21,7 @@ function RestError (type, status, code, message, headers) {
   this.code = code
   this.message = message || null
   this.headers = headers
+  this.isHttpResponsesError = true;
 }
 
 util.inherits(RestError, Error)


### PR DESCRIPTION
Added a simple boolean to the error object to allow throwing and catching of http-responses errors in promises. Without this boolean there isn't an easy way to catch these errors and know whether they're a syntax/reference/etc error or one thrown from this library.